### PR TITLE
Fix TypeScript typings for Playwright MCP agent usage

### DIFF
--- a/src/agentic-test-executor.ts
+++ b/src/agentic-test-executor.ts
@@ -1,13 +1,13 @@
-import { AgenticTestConfig, TestExecutionResult } from './types';
+import type { AgenticTestConfig, TestExecutionResult, PlaywrightMcpAgent } from './types';
 import { Logger } from './logger';
 import { DatabaseService } from './database';
 
 export class AgenticTestExecutor {
   private logger: Logger;
   private db: DatabaseService;
-  private playwright: PlaywrightMCP;
+  private playwright: PlaywrightMcpAgent;
 
-  constructor(playwright: any, db: DatabaseService, logger: Logger) {
+  constructor(playwright: PlaywrightMcpAgent, db: DatabaseService, logger: Logger) {
     this.playwright = playwright;
     this.db = db;
     this.logger = logger;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@ import { DatabaseService } from './database';
 import { Logger } from './logger';
 import { TraditionalTestExecutor } from './traditional-test-executor';
 import { AgenticTestExecutor } from './agentic-test-executor';
+import type { PlaywrightMcpAgent } from './types';
 import { SystemInstruction, TraditionalTestCase, AgenticTestConfig } from './types';
 
-export const PlaywrightMCP = createMcpAgent(env.BROWSER);
+export const PlaywrightMCP = createMcpAgent(env.BROWSER) as unknown as PlaywrightMcpAgent;
 
 // Generate unique session ID
 function generateSessionId(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { AgenticTestExecutor } from './agentic-test-executor';
 import type { PlaywrightMcpAgent } from './types';
 import { SystemInstruction, TraditionalTestCase, AgenticTestConfig } from './types';
 
-export const PlaywrightMCP = createMcpAgent(env.BROWSER) as unknown as PlaywrightMcpAgent;
+export const PlaywrightMCP = createMcpAgent(env.BROWSER) as PlaywrightMcpAgent;
 
 // Generate unique session ID
 function generateSessionId(): string {

--- a/src/traditional-test-executor.ts
+++ b/src/traditional-test-executor.ts
@@ -1,13 +1,19 @@
-import { TraditionalTestCase, TestStep, TestAssertion, TestExecutionResult } from './types';
+import type {
+  TraditionalTestCase,
+  TestStep,
+  TestAssertion,
+  TestExecutionResult,
+  PlaywrightMcpAgent
+} from './types';
 import { Logger } from './logger';
 import { DatabaseService } from './database';
 
 export class TraditionalTestExecutor {
   private logger: Logger;
   private db: DatabaseService;
-  private playwright: PlaywrightMCP;
+  private playwright: PlaywrightMcpAgent;
 
-  constructor(playwright: any, db: DatabaseService, logger: Logger) {
+  constructor(playwright: PlaywrightMcpAgent, db: DatabaseService, logger: Logger) {
     this.playwright = playwright;
     this.db = db;
     this.logger = logger;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
+interface McpAgentFetcher {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response>;
+}
+
 export interface PlaywrightMcpAgent {
-  serve(path: string): {
-    fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response>;
-  };
-  serveSSE(path: string): {
-    fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response>;
-  };
+  serve(path: string): McpAgentFetcher;
+  serveSSE(path: string): McpAgentFetcher;
   navigate(url: string): Promise<unknown>;
   click(selector: string): Promise<unknown>;
   type(selector: string, text: string): Promise<unknown>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,18 @@
+export interface PlaywrightMcpAgent {
+  serve(path: string): {
+    fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response>;
+  };
+  serveSSE(path: string): {
+    fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response>;
+  };
+  navigate(url: string): Promise<unknown>;
+  click(selector: string): Promise<unknown>;
+  type(selector: string, text: string): Promise<unknown>;
+  selectOption(selector: string, value: string): Promise<unknown>;
+  takeScreenshot(): Promise<string>;
+  snapshot(): Promise<string>;
+}
+
 export interface SystemInstruction {
   id?: number;
   url_pattern: string;


### PR DESCRIPTION
## Summary
- add a `PlaywrightMcpAgent` interface to describe the MCP agent methods used by the workers
- update the agentic and traditional test executors to depend on the shared agent interface instead of `any`
- cast the `createMcpAgent` instance to the shared interface to align type information across the codebase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e46c3178832e83e43a8e3eb17df1