### PR TITLE
feat: add unit test run storage and UI

### DIFF
--- a/migrations/0003_unit_tests.sql
+++ b/migrations/0003_unit_tests.sql
@@ -1,0 +1,19 @@
+-- Migration to create unit_test_runs table for storing unit test executions
+CREATE TABLE IF NOT EXISTS unit_test_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id TEXT NOT NULL,
+  test_session_id TEXT,
+  test_result_id INTEGER,
+  test_id TEXT NOT NULL,
+  test_name TEXT NOT NULL,
+  test_code TEXT,
+  test_logs TEXT,
+  ai_response TEXT,
+  status TEXT NOT NULL CHECK (status IN ('PASS', 'FAIL')),
+  started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  finished_at DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_unit_test_runs_run_id ON unit_test_runs(run_id);
+CREATE INDEX IF NOT EXISTS idx_unit_test_runs_status ON unit_test_runs(status);
+CREATE INDEX IF NOT EXISTS idx_unit_test_runs_started_at ON unit_test_runs(started_at);

--- a/public/tests.html
+++ b/public/tests.html
@@ -62,6 +62,10 @@
       grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     }
 
+    .full-width {
+      grid-column: 1 / -1;
+    }
+
     section {
       background: rgba(15, 23, 42, 0.82);
       border-radius: 20px;
@@ -164,6 +168,99 @@
       border-color: rgba(248, 113, 113, 0.4);
     }
 
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.95rem;
+    }
+
+    th, td {
+      padding: 0.75rem 0.5rem;
+      text-align: left;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
+    th {
+      font-weight: 600;
+      color: rgba(226, 232, 240, 0.85);
+    }
+
+    tr:last-child td {
+      border-bottom: none;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.2rem 0.7rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      background: rgba(59, 130, 246, 0.25);
+      border: 1px solid rgba(59, 130, 246, 0.35);
+    }
+
+    .chip.pass {
+      background: rgba(34, 197, 94, 0.18);
+      border-color: rgba(34, 197, 94, 0.35);
+    }
+
+    .chip.fail {
+      background: rgba(248, 113, 113, 0.2);
+      border-color: rgba(248, 113, 113, 0.35);
+    }
+
+    .modal {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.8);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      z-index: 1000;
+    }
+
+    .modal.open {
+      display: flex;
+    }
+
+    .modal-content {
+      background: rgba(15, 23, 42, 0.95);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 16px;
+      max-width: 720px;
+      width: 100%;
+      max-height: 80vh;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .modal-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .modal-body {
+      padding: 1.25rem;
+      overflow: auto;
+    }
+
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      background: rgba(15, 23, 42, 0.85);
+      border-radius: 12px;
+      padding: 1rem;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
     code {
       background: rgba(15, 23, 42, 0.85);
       padding: 0.35rem 0.55rem;
@@ -247,12 +344,50 @@
           <div id="agentic-status" class="status"></div>
         </form>
       </section>
+
+      <section class="full-width" id="unit-tests-panel">
+        <h2>Run Unit Tests</h2>
+        <p>Trigger the Vitest suite and stream results from recent runs. Results are persisted in D1 for historical analysis and AI annotations.</p>
+        <div style="display:flex;flex-wrap:wrap;gap:0.75rem;align-items:center;">
+          <button id="unit-tests-run">Run All Unit Tests</button>
+          <span id="unit-tests-status" class="status" style="display:none; margin:0; min-width:260px;"></span>
+        </div>
+        <div id="unit-tests-summary" style="display:flex;gap:1rem;flex-wrap:wrap;font-size:0.95rem;color:rgba(226,232,240,0.8);"></div>
+        <div class="table-wrapper" style="overflow:auto;border-radius:12px;border:1px solid rgba(148,163,184,0.25);">
+          <table>
+            <thead>
+              <tr>
+                <th>Test name</th>
+                <th>Status</th>
+                <th>Logs</th>
+                <th>AI analysis</th>
+                <th>Code</th>
+              </tr>
+            </thead>
+            <tbody id="unit-tests-body">
+              <tr><td colspan="5" style="text-align:center;padding:1.5rem;color:rgba(148,163,184,0.75);">No unit test run selected.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
     </div>
   </main>
 
   <footer>
     <p>Results and logs are persisted to D1 and visible through both REST endpoints and the MCP interface.</p>
   </footer>
+
+  <div id="unit-tests-modal" class="modal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="unit-modal-title" style="margin:0;font-size:1.2rem;"></h3>
+        <button id="unit-modal-close" type="button">Close</button>
+      </div>
+      <div class="modal-body">
+        <pre id="unit-modal-body">No data.</pre>
+      </div>
+    </div>
+  </div>
 
   <script>
     const traditionalForm = document.getElementById('traditional-form');
@@ -263,6 +398,17 @@
     const agenticUseConfig = document.getElementById('agentic-use-config');
     const traditionalPayload = document.getElementById('traditional-payload');
     const agenticPayload = document.getElementById('agentic-payload');
+
+    const unitTestsRunButton = document.getElementById('unit-tests-run');
+    const unitTestsStatus = document.getElementById('unit-tests-status');
+    const unitTestsSummary = document.getElementById('unit-tests-summary');
+    const unitTestsBody = document.getElementById('unit-tests-body');
+    const unitModal = document.getElementById('unit-tests-modal');
+    const unitModalTitle = document.getElementById('unit-modal-title');
+    const unitModalBody = document.getElementById('unit-modal-body');
+    const unitModalClose = document.getElementById('unit-modal-close');
+    let currentRunId = null;
+    let pollTimer = null;
 
     traditionalUseConfig.addEventListener('change', () => togglePayload(traditionalUseConfig, traditionalPayload));
     agenticUseConfig.addEventListener('change', () => togglePayload(agenticUseConfig, agenticPayload));
@@ -278,6 +424,46 @@
       event.preventDefault();
       await runWithStatus(agenticStatus, executeAgentic());
     });
+
+    unitTestsRunButton?.addEventListener('click', async () => {
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+
+      try {
+        unitTestsRunButton.disabled = true;
+        unitTestsStatus.style.display = 'block';
+        unitTestsStatus.classList.remove('error');
+        unitTestsStatus.textContent = 'Initializing unit test run…';
+
+        const response = await fetch('/tests/run-unit', { method: 'POST' });
+        if (!response.ok) {
+          throw new Error(await response.text());
+        }
+
+        const data = await response.json();
+        currentRunId = data.run_id;
+        unitTestsStatus.textContent = `${data.message} (run: ${currentRunId})`;
+        await refreshUnitRuns();
+        pollTimer = window.setInterval(() => pollUnitRun(currentRunId), 2000);
+        await pollUnitRun(currentRunId);
+      } catch (error) {
+        unitTestsStatus.classList.add('error');
+        unitTestsStatus.textContent = error instanceof Error ? error.message : String(error);
+      } finally {
+        unitTestsRunButton.disabled = false;
+      }
+    });
+
+    unitModalClose?.addEventListener('click', () => closeModal());
+    unitModal?.addEventListener('click', (event) => {
+      if (event.target === unitModal) {
+        closeModal();
+      }
+    });
+
+    loadLatestUnitRun();
 
     function togglePayload(toggle, field) {
       field.disabled = toggle.checked;
@@ -367,6 +553,120 @@
         throw new Error(errorMessage);
       }
     }
+
+    async function pollUnitRun(runId) {
+      if (!runId) return;
+      try {
+        const response = await fetch(`/tests/unit-results?run_id=${encodeURIComponent(runId)}`);
+        if (!response.ok) {
+          throw new Error(await response.text());
+        }
+
+        const data = await response.json();
+        renderUnitResults(data.results);
+        renderUnitSummary(data.stats, runId, data.completed);
+
+        if (data.completed && pollTimer) {
+          clearInterval(pollTimer);
+          pollTimer = null;
+          await refreshUnitRuns();
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    async function loadLatestUnitRun() {
+      try {
+        const response = await fetch('/tests/unit-latest');
+        if (!response.ok) return;
+        const data = await response.json();
+        if (data?.run?.run_id) {
+          renderUnitSummary(data.run.stats, data.run.run_id, data.rows.every(r => r.finished_at));
+          renderUnitResults(data.rows);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    async function refreshUnitRuns() {
+      try {
+        const response = await fetch('/tests/unit-runs');
+        if (!response.ok) return;
+        const data = await response.json();
+        if (Array.isArray(data.runs) && data.runs.length > 0) {
+          const [latest] = data.runs;
+          renderUnitSummary({ total: latest.total, passed: latest.passed, failed: latest.failed }, latest.run_id, Boolean(latest.finished_at));
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    function renderUnitResults(results = []) {
+      if (!Array.isArray(results) || results.length === 0) {
+        unitTestsBody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:1.5rem;color:rgba(148,163,184,0.75);">No unit test results yet.</td></tr>';
+        return;
+      }
+
+      unitTestsBody.innerHTML = '';
+      results.forEach((row) => {
+        const tr = document.createElement('tr');
+        const status = row.status === 'PASS' ? 'pass' : 'fail';
+        tr.innerHTML = `
+          <td>${escapeHtml(row.test_name || row.test_id)}</td>
+          <td><span class="chip ${status}">${status === 'pass' ? '✅ Pass' : '❌ Fail'}</span></td>
+          <td><button type="button" data-kind="logs" data-title="Logs for ${escapeHtml(row.test_name || row.test_id)}" data-content="${encodeURIComponent(row.test_logs || 'No logs captured.')}">View logs</button></td>
+          <td><button type="button" data-kind="ai" data-title="AI analysis for ${escapeHtml(row.test_name || row.test_id)}" data-content="${encodeURIComponent(row.ai_response || 'AI analysis unavailable.')}">View AI analysis</button></td>
+          <td><button type="button" data-kind="code" data-title="Test code for ${escapeHtml(row.test_name || row.test_id)}" data-content="${encodeURIComponent(row.test_code || 'Code not provided.')}">View code</button></td>
+        `;
+        unitTestsBody.appendChild(tr);
+      });
+
+      unitTestsBody.querySelectorAll('button[data-kind]').forEach((button) => {
+        button.addEventListener('click', () => {
+          const title = button.getAttribute('data-title') || 'Details';
+          const content = decodeURIComponent(button.getAttribute('data-content') || '');
+          openModal(title, content);
+        });
+      });
+    }
+
+    function renderUnitSummary(stats, runId, completed) {
+      if (!stats) return;
+      unitTestsSummary.innerHTML = '';
+      const statusChip = document.createElement('div');
+      statusChip.className = `chip ${completed ? 'pass' : ''}`;
+      statusChip.textContent = completed ? 'Completed' : 'In progress';
+      unitTestsSummary.appendChild(statusChip);
+
+      const summaryText = document.createElement('div');
+      summaryText.innerHTML = `<strong>Run:</strong> ${escapeHtml(runId || 'n/a')} · <strong>Total:</strong> ${stats.total || 0} · <strong>Passed:</strong> ${stats.passed || 0} · <strong>Failed:</strong> ${stats.failed || 0}`;
+      unitTestsSummary.appendChild(summaryText);
+    }
+
+    function openModal(title, content) {
+      if (!unitModal || !unitModalTitle || !unitModalBody) return;
+      unitModalTitle.textContent = title;
+      unitModalBody.textContent = content;
+      unitModal.classList.add('open');
+    }
+
+    function closeModal() {
+      if (!unitModal) return;
+      unitModal.classList.remove('open');
+    }
+
+    function escapeHtml(value = '') {
+      return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+    }
   </script>
+
 </body>
 </html>

--- a/scripts/run-vitest.ts
+++ b/scripts/run-vitest.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env ts-node
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+
+function parseRunId(): string | undefined {
+  const flagIndex = process.argv.indexOf('--run-id')
+  if (flagIndex !== -1 && process.argv[flagIndex + 1]) {
+    return process.argv[flagIndex + 1]
+  }
+  return process.env.VITEST_RUN_ID
+}
+
+async function main() {
+  const runId = parseRunId() || `unit_${Date.now()}`
+  process.env.VITEST_RUN_ID = runId
+
+  const reporterPath = path.resolve(__dirname, '../tests/reporters/unit-d1-reporter.ts')
+  const args = ['vitest', 'run', '--reporter', 'default', '--reporter', reporterPath]
+
+  const child = spawn('pnpm', args, {
+    stdio: 'inherit',
+    env: process.env,
+    shell: false,
+  })
+
+  child.on('exit', (code) => {
+    if (code !== 0) {
+      process.stderr.write(`Vitest exited with status ${code}\n`)
+      process.exit(code ?? 1)
+    }
+
+    const outputPath = path.resolve(process.cwd(), '.vitest-runs', `${runId}.json`)
+    process.stdout.write(`Results saved to ${outputPath}\n`)
+    process.exit(0)
+  })
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,21 @@ export interface TestResult {
   timestamp?: string;
 }
 
+export interface UnitTestRunRecord {
+  id?: number;
+  run_id: string;
+  test_session_id?: string | null;
+  test_result_id?: number | null;
+  test_id: string;
+  test_name: string;
+  test_code?: string | null;
+  test_logs?: string | null;
+  ai_response?: string | null;
+  status: 'PASS' | 'FAIL';
+  started_at?: string;
+  finished_at?: string | null;
+}
+
 export interface TraditionalTestCase {
   name: string;
   steps: TestStep[];

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -1,65 +1,685 @@
-import { describe, it, beforeAll, expect } from 'vitest'
-import worker from '../src/index'
+import { describe, it, beforeAll, beforeEach, expect, vi } from 'vitest'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
 
-// Minimal Env shim
-class InMemoryD1 {
-  private data = new Map<string, any[]>()
-  async exec(_sql: string) { return { success: true } as any }
-  prepare(_sql: string) { return {
-    bind: (..._args: any[]) => ({
-      all: async () => ({ results: [] }),
-      first: async () => ({}),
-      run: async () => ({ meta: { last_row_id: 1, changes: 1 } }),
-    }),
-    all: async () => ({ results: [] }),
-  } as any }
+type SystemInstruction = {
+  id: number
+  url_pattern: string
+  name: string
+  instructions: string
+  test_type: 'traditional' | 'agentic'
+  is_active?: boolean
 }
 
-function makeEnv(): Env {
+type TestSession = {
+  id: string
+  url: string
+  test_type: 'traditional' | 'agentic'
+  status: 'running' | 'completed' | 'failed' | 'cancelled'
+  config_id?: number
+  start_time?: string
+  end_time?: string | null
+  results?: string | null
+  error_summary?: string | null
+}
+
+type UnitRunRow = {
+  id: number
+  run_id: string
+  test_id: string
+  test_name: string
+  status: 'PASS' | 'FAIL'
+  test_logs?: string | null
+  test_code?: string | null
+  ai_response?: string | null
+  started_at?: string | null
+  finished_at?: string | null
+}
+
+const dbState = vi.hoisted(() => {
+  const state = {
+    instructionSeq: 0,
+    unitRunSeq: 0,
+    instructions: [] as SystemInstruction[],
+    sessions: new Map<string, TestSession>(),
+    actionLogs: [] as Array<{ session_id: string; action_type: string; timestamp: string }>,
+    testResults: [] as Array<{ session_id: string; test_name: string; status: string }>,
+    unitRuns: [] as UnitRunRow[],
+    failEnsureSchema: false,
+    failGetSchema: false,
+    reset() {
+      this.instructionSeq = 0
+      this.unitRunSeq = 0
+      this.instructions = []
+      this.sessions = new Map()
+      this.actionLogs = []
+      this.testResults = []
+      this.unitRuns = []
+      this.failEnsureSchema = false
+      this.failGetSchema = false
+    },
+  }
+  state.reset()
+  return state
+})
+
+vi.mock('../src/database', () => {
+  const state = dbState
+
+  class FakeDatabaseService {
+    constructor(_db: unknown) {}
+
+    async ensureSchema() {
+      if (state.failEnsureSchema) {
+        throw new Error('failed to ensure schema')
+      }
+      return { createdTables: [], existingTables: ['system_instructions', 'unit_test_runs'] }
+    }
+
+    async getSchemaOverview() {
+      if (state.failGetSchema) {
+        throw new Error('schema introspection failed')
+      }
+
+      return {
+        tables: [
+          {
+            name: 'system_instructions',
+            rowCount: state.instructions.length,
+            columns: [],
+            indexes: [],
+          },
+          {
+            name: 'unit_test_runs',
+            rowCount: state.unitRuns.length,
+            columns: [],
+            indexes: [],
+          },
+        ],
+      }
+    }
+
+    async createSystemInstruction(instruction: Omit<SystemInstruction, 'id'>) {
+      const id = ++state.instructionSeq
+      state.instructions.push({ id, ...instruction, is_active: instruction.is_active ?? true })
+      return id
+    }
+
+    async getSystemInstructionByUrl(url: string, testType?: 'traditional' | 'agentic') {
+      const found = state.instructions
+        .filter(config => config.is_active !== false)
+        .filter(config => (testType ? config.test_type === testType : true))
+        .filter(config => url.includes(config.url_pattern))
+        .sort((a, b) => b.url_pattern.length - a.url_pattern.length)
+      return found[0] ?? null
+    }
+
+    async getAllSystemInstructions() {
+      return [...state.instructions]
+    }
+
+    async updateSystemInstruction(id: number, updates: Partial<SystemInstruction>) {
+      const config = state.instructions.find(item => item.id === id)
+      if (config) {
+        Object.assign(config, updates)
+      }
+    }
+
+    async deleteSystemInstruction(id: number) {
+      const config = state.instructions.find(item => item.id === id)
+      if (config) {
+        config.is_active = false
+      }
+    }
+
+    async logAction(log: any) {
+      state.actionLogs.push({ session_id: log.session_id, action_type: log.action_type, timestamp: new Date().toISOString() })
+    }
+
+    async getActionLogs(sessionId: string) {
+      return state.actionLogs.filter(log => log.session_id === sessionId)
+    }
+
+    async createTestSession(session: TestSession) {
+      state.sessions.set(session.id, { ...session, start_time: new Date().toISOString() })
+    }
+
+    async updateTestSession(sessionId: string, updates: Partial<TestSession>) {
+      const session = state.sessions.get(sessionId)
+      if (session) {
+        Object.assign(session, updates)
+      }
+    }
+
+    async getTestSession(sessionId: string) {
+      return state.sessions.get(sessionId) ?? null
+    }
+
+    async getAllTestSessions(limit = 50) {
+      return Array.from(state.sessions.values())
+        .sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''))
+        .slice(0, limit)
+    }
+
+    async saveTestResult(result: any) {
+      state.testResults.push(result)
+    }
+
+    async getTestResults(sessionId: string) {
+      return state.testResults.filter(result => result.session_id === sessionId)
+    }
+
+    async getSessionStats(sessionId: string) {
+      const results = state.testResults.filter(result => result.session_id === sessionId)
+      const total = results.length
+      const passed = results.filter(result => result.status === 'passed').length
+      const failed = results.filter(result => result.status === 'failed').length
+      return {
+        total_actions: state.actionLogs.filter(log => log.session_id === sessionId).length,
+        total_errors: failed,
+        avg_execution_time: 0,
+        test_results_summary: { passed, failed, skipped: total - passed - failed },
+      }
+    }
+
+    async cleanupOldSessions() {
+      return 0
+    }
+
+    async createUnitTestRow(row: any) {
+      const id = ++state.unitRunSeq
+      state.unitRuns.push({ id, ...row })
+      return id
+    }
+
+    async completeUnitTestRow(id: number, updates: Partial<UnitRunRow>) {
+      const row = state.unitRuns.find(item => item.id === id)
+      if (row) {
+        Object.assign(row, updates)
+      }
+    }
+
+    async listUnitTestRuns(runId: string) {
+      return state.unitRuns.filter(row => row.run_id === runId)
+    }
+
+    async listRecentUnitRuns(limit = 10) {
+      const grouped = new Map<string, { run_id: string; started_at: string | null; finished_at: string | null; total: number; passed: number; failed: number }>()
+      for (const row of state.unitRuns) {
+        if (!grouped.has(row.run_id)) {
+          grouped.set(row.run_id, {
+            run_id: row.run_id,
+            started_at: row.started_at ?? null,
+            finished_at: row.finished_at ?? null,
+            total: 0,
+            passed: 0,
+            failed: 0,
+          })
+        }
+        const bucket = grouped.get(row.run_id)!
+        bucket.total += 1
+        if (row.status === 'PASS') bucket.passed += 1
+        else bucket.failed += 1
+        bucket.started_at = bucket.started_at ?? row.started_at ?? null
+        bucket.finished_at = row.finished_at ?? bucket.finished_at ?? null
+      }
+      return Array.from(grouped.values()).sort((a, b) => (b.started_at ?? '').localeCompare(a.started_at ?? '')).slice(0, limit)
+    }
+
+    async getLatestUnitRun() {
+      const recent = await this.listRecentUnitRuns(1)
+      if (!recent.length) return null
+      const run = recent[0]
+      const rows = await this.listUnitTestRuns(run.run_id)
+      return {
+        run: {
+          run_id: run.run_id,
+          started_at: run.started_at,
+          finished_at: run.finished_at,
+          stats: { total: run.total, passed: run.passed, failed: run.failed },
+        },
+        rows,
+      }
+    }
+  }
+
+  return { DatabaseService: FakeDatabaseService, __dbState: state }
+})
+
+vi.mock('../src/logger', () => {
+  class FakeLogger {
+    async logInfo() {}
+    async logWarning() {}
+    async logError() {}
+    async logSessionStart() {}
+    async logSessionEnd() {}
+    async logTestStart() {}
+    async logTestEnd() {}
+    async timedExecution(_name: string, _meta: unknown, fn: () => Promise<unknown>) {
+      return fn()
+    }
+  }
+  return { Logger: FakeLogger }
+})
+
+vi.mock('../src/traditional-test-executor', () => {
+  class FakeTraditionalTestExecutor {
+    constructor() {}
+    async executeTest(sessionId: string) {
+      const success = !sessionId.includes('fail')
+      return {
+        session_id: sessionId,
+        success,
+        results: [],
+        logs: [],
+        screenshots: [],
+        execution_time_ms: 25,
+        error_summary: success ? undefined : 'failure detected',
+      }
+    }
+  }
+  return { TraditionalTestExecutor: FakeTraditionalTestExecutor }
+})
+
+vi.mock('../src/agentic-test-executor', () => {
+  class FakeAgenticTestExecutor {
+    constructor() {}
+    async executeTest(sessionId: string) {
+      return {
+        session_id: sessionId,
+        success: true,
+        results: [],
+        logs: [],
+        screenshots: [],
+        execution_time_ms: 30,
+      }
+    }
+  }
+  return { AgenticTestExecutor: FakeAgenticTestExecutor }
+})
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+let workerInstance: any | null = null
+
+async function getWorker() {
+  if (!workerInstance) {
+    workerInstance = (await import('../src/index')).default
+  }
+  return workerInstance
+}
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  const assetsRoot = path.resolve(__dirname, '../public')
+  const assetFetcher = {
+    async fetch(request: Request) {
+      const url = new URL(request.url)
+      let pathname = url.pathname
+      if (pathname === '/') pathname = '/index.html'
+      const filePath = path.join(assetsRoot, pathname.replace(/^\//, ''))
+      try {
+        const data = await fs.readFile(filePath)
+        return new Response(data, { status: 200 })
+      } catch {
+        return new Response('Not Found', { status: 404 })
+      }
+    },
+  }
+
   return {
-    DB: new InMemoryD1() as unknown as D1Database,
-    ASSETS: { fetch: (req: Request) => fetch(new URL(req.url).toString()) } as any,
+    DB: {} as unknown as D1Database,
+    ASSETS: assetFetcher as any,
     BROWSER: {} as any,
+    ...overrides,
   } as Env
 }
 
-async function call(path: string, init?: RequestInit) {
-  const url = 'https://example.com' + path
-  const req = new Request(url, init)
-  const res = await (worker as any).fetch(req, makeEnv(), {} as any)
-  return res
+async function call(pathname: string, init?: RequestInit) {
+  const url = `https://example.com${pathname}`
+  const request = new Request(url, init)
+  const worker = await getWorker()
+  const response = await worker.fetch(request, makeEnv(), {} as any)
+  return response
+}
+const resetState = () => {
+  dbState.reset()
 }
 
-describe('API smoke tests', () => {
-  it('serves health', async () => {
-    const res = await call('/health')
-    expect(res.status).toBe(200)
-    const json = await res.json()
-    expect(json.status).toBe('healthy')
+describe('admin endpoints', () => {
+  beforeEach(resetState)
+  it('ensures schema successfully', async () => {
+    const response = await call('/admin/setup', { method: 'POST' })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.message).toContain('Database schema ensured')
   })
 
-  it('serves not found for unknown', async () => {
-    const res = await call('/nope')
-    expect(res.status).toBe(404)
+  it('returns error when schema setup fails', async () => {
+    dbState.failEnsureSchema = true
+    const response = await call('/admin/setup', { method: 'POST' })
+    expect(response.status).toBe(500)
   })
 
-  it('serves config page asset', async () => {
-    const res = await call('/config', { method: 'GET' })
-    expect(res.status).toBe(200)
-    const text = await res.text()
-    expect(text).toMatch(/D1 Configuration Console/)
+  it('returns schema overview', async () => {
+    await call('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url_pattern: 'https://example.com', name: 'Example', instructions: '{}', test_type: 'traditional' }),
+    })
+
+    const response = await call('/admin/schema')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body.tables)).toBe(true)
+    expect(body.tables.length).toBeGreaterThan(0)
   })
 
-  it('returns configs list (empty)', async () => {
-    const res = await call('/config.json')
-    expect(res.status).toBe(200)
-    const json = await res.json()
-    expect(json.configs).toBeDefined()
+  it('fails schema overview when database throws', async () => {
+    dbState.failGetSchema = true
+    const response = await call('/admin/schema')
+    expect(response.status).toBe(500)
   })
 
-  it('rejects bad create payload', async () => {
-    const res = await call('/config.json', { method: 'POST', body: '{}', headers: { 'Content-Type': 'application/json' } })
-    expect(res.status).toBe(400)
+  it('provides diagnostics information', async () => {
+    const response = await call('/admin/diag')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.status).toBe('ok')
+    expect(body.tables).toBeGreaterThanOrEqual(0)
   })
 })
 
+describe('config endpoints', () => {
+  beforeEach(resetState)
+  it('lists configurations', async () => {
+    const response = await call('/config.json')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body.configs)).toBe(true)
+  })
+
+  it('rejects invalid creation payload', async () => {
+    const response = await call('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it('creates and updates configuration', async () => {
+    const create = await call('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url_pattern: 'https://foo.dev', name: 'Foo', instructions: '{}', test_type: 'traditional' }),
+    })
+    const createBody = await create.json()
+    const update = await call('/config.json', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: createBody.id, name: 'Updated Foo' }),
+    })
+    expect(update.status).toBe(200)
+  })
+
+  it('rejects update without id', async () => {
+    const response = await call('/config.json', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Missing id' }),
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it('deletes configuration', async () => {
+    const create = await call('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url_pattern: 'https://bar.dev', name: 'Bar', instructions: '{}', test_type: 'agentic' }),
+    })
+    const { id } = await create.json()
+    const response = await call(`/config.json?id=${id}`, { method: 'DELETE' })
+    expect(response.status).toBe(200)
+  })
+
+  it('finds configuration by url and type', async () => {
+    await call('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url_pattern: 'example.com', name: 'Stored', instructions: '{}', test_type: 'traditional' }),
+    })
+
+    const response = await call('/config/find?url=https://example.com/page')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.config).toBeTruthy()
+  })
+
+  it('returns error when url is missing in find', async () => {
+    const response = await call('/config/find')
+    expect(response.status).toBe(400)
+  })
+})
+
+describe('test execution endpoints', () => {
+  beforeEach(resetState)
+  it('runs traditional test with stored config', async () => {
+    await call('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url_pattern: 'https://site.test',
+        name: 'Stored Traditional',
+        instructions: JSON.stringify({ name: 'Stored Test', steps: [], assertions: [] }),
+        test_type: 'traditional',
+      }),
+    })
+
+    const response = await call('/test/traditional', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'https://site.test/home' }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+  })
+
+  it('rejects traditional test without config or payload', async () => {
+    const response = await call('/test/traditional', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'https://missing.test', useStoredConfig: true }),
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it('runs agentic test with stored config', async () => {
+    await call('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url_pattern: 'agentic.test',
+        name: 'Agentic Config',
+        instructions: JSON.stringify({ goal: 'Check', context: '', success_criteria: [] }),
+        test_type: 'agentic',
+      }),
+    })
+
+    const response = await call('/test/agentic', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'https://agentic.test/run' }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+  })
+
+  it('rejects agentic test without configuration', async () => {
+    const response = await call('/test/agentic', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'https://unknown.test' }),
+    })
+    expect(response.status).toBe(400)
+  })
+})
+
+describe('session endpoints', () => {
+  beforeEach(resetState)
+  beforeEach(() => {
+    const session: TestSession = {
+      id: 'session-1',
+      url: 'https://example.com',
+      test_type: 'traditional',
+      status: 'completed',
+      start_time: new Date().toISOString(),
+    }
+    dbState.sessions.set(session.id, { ...session })
+    dbState.testResults.push({ session_id: session.id, test_name: 'Example', status: 'passed' })
+    dbState.actionLogs.push({ session_id: session.id, action_type: 'info', timestamp: new Date().toISOString() })
+  })
+
+  it('lists sessions when no id provided', async () => {
+    const response = await call('/session')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body.sessions)).toBe(true)
+    expect(body.sessions.length).toBeGreaterThan(0)
+  })
+
+  it('returns specific session information', async () => {
+    const response = await call('/session?sessionId=session-1')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.session.id).toBe('session-1')
+    expect(Array.isArray(body.logs)).toBe(true)
+  })
+
+  it('returns 404 for unknown session', async () => {
+    const response = await call('/session?sessionId=unknown')
+    expect(response.status).toBe(404)
+  })
+
+  it('cancels a session', async () => {
+    const response = await call('/session?sessionId=session-1', { method: 'DELETE' })
+    expect(response.status).toBe(200)
+    expect(dbState.sessions.get('session-1')?.status).toBe('cancelled')
+  })
+
+  it('rejects cancel without session id', async () => {
+    const response = await call('/session', { method: 'DELETE' })
+    expect(response.status).toBe(400)
+  })
+})
+
+describe('asset endpoints', () => {
+  beforeEach(resetState)
+  it('serves home page', async () => {
+    const response = await call('/')
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('<!DOCTYPE html>')
+  })
+
+  it('serves config and tests dashboards', async () => {
+    const configRes = await call('/config')
+    const testsRes = await call('/tests.html')
+    const sessionsRes = await call('/sessions.html')
+    expect(configRes.status).toBe(200)
+    expect(testsRes.status).toBe(200)
+    expect(sessionsRes.status).toBe(200)
+  })
+
+  it('returns 404 for missing asset', async () => {
+    const response = await call('/no-such-asset.html')
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('health endpoint', () => {
+  beforeEach(resetState)
+  it('returns healthy status', async () => {
+    const response = await call('/health')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.status).toBe('healthy')
+  })
+
+  it('returns error when database check fails', async () => {
+    dbState.failGetSchema = true
+    const response = await call('/health')
+    expect(response.status).toBe(503)
+  })
+})
+
+describe('unit test result workflow', () => {
+  beforeEach(resetState)
+  it('initializes a run and records placeholder', async () => {
+    const response = await call('/tests/run-unit', { method: 'POST' })
+    expect(response.status).toBe(201)
+    const body = await response.json()
+    expect(body.run_id).toMatch(/^unit_/)
+    expect(dbState.unitRuns.some(row => row.run_id === body.run_id)).toBe(true)
+  })
+
+  it('imports unit test results and stores AI analysis placeholder', async () => {
+    const response = await call('/tests/unit-results/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        run_id: 'run-123',
+        results: [
+          { test_id: 't1', test_name: 'passes', test_logs: 'ok', test_code: 'expect(true)', status: 'PASS' },
+          { test_id: 't2', test_name: 'fails', test_logs: 'boom', test_code: 'throw', status: 'FAIL' },
+        ],
+      }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.stats.total).toBe(2)
+    expect(body.stats.failed).toBe(1)
+    const stored = dbState.unitRuns.filter(row => row.run_id === 'run-123')
+    expect(stored.length).toBe(2)
+    expect(stored[0].ai_response).toBeTruthy()
+  })
+
+  it('rejects invalid import payload', async () => {
+    const response = await call('/tests/unit-results/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it('lists run results and summaries', async () => {
+    await call('/tests/unit-results/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        run_id: 'run-abc',
+        results: [
+          { test_id: 'x', test_name: 'one', status: 'PASS' },
+        ],
+      }),
+    })
+
+    const listRes = await call('/tests/unit-results?run_id=run-abc')
+    expect(listRes.status).toBe(200)
+    const listBody = await listRes.json()
+    expect(listBody.stats.total).toBe(1)
+
+    const latestRes = await call('/tests/unit-latest')
+    expect(latestRes.status).toBe(200)
+    const latestBody = await latestRes.json()
+    expect(latestBody.run.run_id).toBe('run-abc')
+
+    const runsRes = await call('/tests/unit-runs')
+    expect(runsRes.status).toBe(200)
+    const runsBody = await runsRes.json()
+    expect(Array.isArray(runsBody.runs)).toBe(true)
+  })
+})

--- a/tests/reporters/unit-d1-reporter.ts
+++ b/tests/reporters/unit-d1-reporter.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { Reporter, File, Task } from 'vitest'
+
+type SerializedTest = {
+  id: string
+  name: string
+  status: 'PASS' | 'FAIL'
+  duration: number
+  error?: string
+  logs: string[]
+}
+
+type ReporterOptions = {
+  runId?: string
+  outputDir?: string
+}
+
+function flattenTask(task: Task, tests: SerializedTest[]) {
+  if ((task as any).type === 'test') {
+    const state = task.result?.state === 'pass' ? 'PASS' : 'FAIL'
+    const logs = (task.logs || []).flatMap(entry => Array.isArray(entry?.content) ? entry.content.map(String) : [String(entry?.content ?? '')])
+    tests.push({
+      id: task.id,
+      name: task.name,
+      status: state,
+      duration: task.result?.duration ?? 0,
+      error: task.result?.error ? serializeError(task.result.error) : undefined,
+      logs: logs.filter(Boolean),
+    })
+  }
+
+  if ('tasks' in task && Array.isArray(task.tasks)) {
+    task.tasks.forEach(child => flattenTask(child, tests))
+  }
+}
+
+function serializeError(error: unknown): string {
+  if (!error) return ''
+  if (typeof error === 'string') return error
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}\n${error.stack ?? ''}`.trim()
+  }
+  return JSON.stringify(error)
+}
+
+export default class UnitD1Reporter implements Reporter {
+  private readonly runId: string
+  private readonly outputFile: string
+
+  constructor(options: ReporterOptions = {}) {
+    this.runId = options.runId || process.env.VITEST_RUN_ID || `unit_${Date.now()}`
+    const outputDir = options.outputDir || path.resolve(process.cwd(), '.vitest-runs')
+    fs.mkdirSync(outputDir, { recursive: true })
+    this.outputFile = path.join(outputDir, `${this.runId}.json`)
+  }
+
+  async onFinished(files: File[]): Promise<void> {
+    const tests: SerializedTest[] = []
+    files.forEach(file => flattenTask(file as unknown as Task, tests))
+
+    const payload = {
+      run_id: this.runId,
+      generated_at: new Date().toISOString(),
+      tests,
+    }
+
+    fs.writeFileSync(this.outputFile, JSON.stringify(payload, null, 2))
+    process.stdout.write(`Vitest unit results saved to ${this.outputFile}\n`)
+  }
+}


### PR DESCRIPTION
## Summary
- add a D1 migration and database helpers for persisting unit test runs and analytics
- expose REST endpoints for triggering runs, importing results, and browsing history including AI analysis
- update the tests dashboard with a unit test control panel plus modal viewers, and add a Vitest reporter/runner script
- expand coverage with detailed Vitest suites that exercise admin, configuration, testing, session, asset, health, and unit import flows

## Testing
- `pnpm test:unit` *(fails: vitest reports "No test suite found" in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b16f4ef0832ebcca8a7ff6ca7aa3